### PR TITLE
POD fix for UserAgent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ nytprof.out
 *.bs
 /_eumm/
 /.idea/
+/examples/config.json
+

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ See unit test in xt folder for more examples
 - Automatic access\_token refresh (if user has refresh\_token) and saving refreshed token to storage
 - CLI tool (_goauth_) with lightweight server for easy OAuth2 authorization and getting access\_ and refresh\_ tokens
 
+# LIMITATIONS
+
+- NB this is a work in progress - use beyond the Calendar API requires some fiddling. eg. scope in the CLI tool (_goauth_) is hard coded etc.
+
 # SEE ALSO
 
 [API::Google](https://metacpan.org/pod/API::Google) - my old lib
@@ -74,8 +78,6 @@ See unit test in xt folder for more examples
     cloudtrace : v1 : https://cloud.google.com/trace
     clouduseraccounts : alpha,beta,vm_alpha,vm_beta : https://cloud.google.com/compute/docs/access/user-accounts/api/latest/
     compute : alpha,beta,v1 : https://developers.google.com/compute/docs/reference/latest/
-    Use of uninitialized value in join or string at lib/Moo/Google/Discovery.pm line 139.
-    consumersurveys : v2 :
     container : v1 : https://cloud.google.com/container-engine/
     content : v2sandbox,v2 : https://developers.google.com/shopping-content
     customsearch : v1 : https://developers.google.com/custom-search/v1/using_rest
@@ -164,9 +166,13 @@ See unit test in xt folder for more examples
 
 Pavel Serikov <pavelsr@cpan.org>
 
+# CONTRIBUTORS
+
+Peter Scott <peter@pscott.com.au>
+
 # COPYRIGHT AND LICENSE
 
-This software is copyright (c) 2017 by Pavel Serikov.
+This software is copyright (c) 2017-2018 by Pavel Serikov.
 
 This is free software; you can redistribute it and/or modify it under
 the same terms as the Perl 5 programming language system itself.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ WebService::Google::Client - Server-side client library for any Google App API. 
 
 # VERSION
 
-version 0.03
+version 0.04
 
 # SYNOPSIS
 
@@ -125,7 +125,7 @@ See unit test in xt folder for more examples
     pubsub : v1beta1a,v1,v1beta2 : https://cloud.google.com/pubsub/docs
     qpxExpress : v1 : http://developers.google.com/qpx-express
     replicapool : v1beta1,v1beta2 : https://developers.google.com/compute/docs/replica-pool/,https://developers.google.com/compute/docs/instance-groups/manager/v1beta2
-    replicapoolupdater : v1beta1 : https://cloud.google.com/compute/docs/instance-groups/manager/#applying_rolling_updates_using_the_updater_service
+    https://cloud.google.com/compute/docs/instance-groups/manager/#applying_rolling_updates_using_the_updater_service
     reseller : v1 : https://developers.google.com/google-apps/reseller/
     resourceviews : v1beta1,v1beta2 : https://developers.google.com/compute/
     runtimeconfig : v1,v1beta1 : https://cloud.google.com/deployment-manager/runtime-configurator/
@@ -146,8 +146,6 @@ See unit test in xt folder for more examples
     storage : v1,v1beta1,v1beta2 : https://developers.google.com/storage/docs/json_api/
     storagetransfer : v1 : https://cloud.google.com/storage/transfer
     supportcases : v2 : https://sites.google.com/a/google.com/cases/
-    Use of uninitialized value in join or string at lib/Moo/Google/Discovery.pm line 139.
-    surveys : v2 :
     tagmanager : v1,v2 : https://developers.google.com/tag-manager/api/v1/,https://developers.google.com/tag-manager/api/v2/
     taskqueue : v1beta1,v1beta2 : https://developers.google.com/appengine/docs/python/taskqueue/rest
     tasks : v1 : https://developers.google.com/google-apps/tasks/firstapp

--- a/README.md
+++ b/README.md
@@ -35,10 +35,6 @@ See unit test in xt folder for more examples
 - Automatic access\_token refresh (if user has refresh\_token) and saving refreshed token to storage
 - CLI tool (_goauth_) with lightweight server for easy OAuth2 authorization and getting access\_ and refresh\_ tokens
 
-# LIMITATIONS
-
-- NB this is a work in progress - use beyond the Calendar API requires some fiddling. eg. scope in the CLI tool (_goauth_) is hard coded etc.
-
 # SEE ALSO
 
 [API::Google](https://metacpan.org/pod/API::Google) - my old lib
@@ -78,6 +74,8 @@ See unit test in xt folder for more examples
     cloudtrace : v1 : https://cloud.google.com/trace
     clouduseraccounts : alpha,beta,vm_alpha,vm_beta : https://cloud.google.com/compute/docs/access/user-accounts/api/latest/
     compute : alpha,beta,v1 : https://developers.google.com/compute/docs/reference/latest/
+    Use of uninitialized value in join or string at lib/Moo/Google/Discovery.pm line 139.
+    consumersurveys : v2 :
     container : v1 : https://cloud.google.com/container-engine/
     content : v2sandbox,v2 : https://developers.google.com/shopping-content
     customsearch : v1 : https://developers.google.com/custom-search/v1/using_rest
@@ -125,7 +123,7 @@ See unit test in xt folder for more examples
     pubsub : v1beta1a,v1,v1beta2 : https://cloud.google.com/pubsub/docs
     qpxExpress : v1 : http://developers.google.com/qpx-express
     replicapool : v1beta1,v1beta2 : https://developers.google.com/compute/docs/replica-pool/,https://developers.google.com/compute/docs/instance-groups/manager/v1beta2
-    https://cloud.google.com/compute/docs/instance-groups/manager/#applying_rolling_updates_using_the_updater_service
+    replicapoolupdater : v1beta1 : https://cloud.google.com/compute/docs/instance-groups/manager/#applying_rolling_updates_using_the_updater_service
     reseller : v1 : https://developers.google.com/google-apps/reseller/
     resourceviews : v1beta1,v1beta2 : https://developers.google.com/compute/
     runtimeconfig : v1,v1beta1 : https://cloud.google.com/deployment-manager/runtime-configurator/
@@ -146,6 +144,8 @@ See unit test in xt folder for more examples
     storage : v1,v1beta1,v1beta2 : https://developers.google.com/storage/docs/json_api/
     storagetransfer : v1 : https://cloud.google.com/storage/transfer
     supportcases : v2 : https://sites.google.com/a/google.com/cases/
+    Use of uninitialized value in join or string at lib/Moo/Google/Discovery.pm line 139.
+    surveys : v2 :
     tagmanager : v1,v2 : https://developers.google.com/tag-manager/api/v1/,https://developers.google.com/tag-manager/api/v2/
     taskqueue : v1beta1,v1beta2 : https://developers.google.com/appengine/docs/python/taskqueue/rest
     tasks : v1 : https://developers.google.com/google-apps/tasks/firstapp
@@ -163,10 +163,6 @@ See unit test in xt folder for more examples
 # AUTHOR
 
 Pavel Serikov <pavelsr@cpan.org>
-
-# CONTRIBUTORS
-
-Peter Scott <peter@pscott.com.au>
 
 # COPYRIGHT AND LICENSE
 

--- a/bin/goauth
+++ b/bin/goauth
@@ -6,7 +6,7 @@ package goauth;
 
 =head1 SYNOPSIS
 
-    goauth [tokens.json]
+    goauth [tokens.json] 
 
     By default if will create config.json in current directory
 
@@ -48,7 +48,7 @@ else {
 
 if ( -e $filename ) {
     say "File $filename exists";
-    input_if_not_exists( [ 'gapi/client_id', 'gapi/client_secret' ] );
+    input_if_not_exists( [ 'gapi/client_id', 'gapi/client_secret', 'gapi/scopes' ] );
     runserver();
 }
 else {
@@ -65,9 +65,15 @@ sub setup {
     chomp( $oauth->{client_id} = <STDIN> );
     print "client_secret: ";
     chomp( $oauth->{client_secret} = <STDIN> );
+
+    print "scopes ( space sep list): ";
+    chomp( $oauth->{scopes} = <STDIN> );
+    
+
     my $tokensfile = Config::JSON->create($filename);
     $tokensfile->set( 'gapi/client_id',     $oauth->{client_id} );
     $tokensfile->set( 'gapi/client_secret', $oauth->{client_secret} );
+    $tokensfile->set( 'gapi/scopes', $oauth->{scopes} );
     say 'OAuth details was updated!';
 
     # Remove comment for Mojolicious::Plugin::JSONConfig compatibility

--- a/dist.ini
+++ b/dist.ini
@@ -2,8 +2,8 @@ name = Moo-Google
 author = Pavel Serikov <pavelsr@cpan.org>
 license = Perl_5
 copyright_holder = Pavel Serikov
-copyright_year = 2017
-version = 0.03
+copyright_year = 2017-2018
+version = 0.04
 
 [PruneCruft]
 [ManifestSkip]

--- a/lib/WebService/Google/Client/Server.pm
+++ b/lib/WebService/Google/Client/Server.pm
@@ -77,6 +77,7 @@ helper get_email => sub {
 
 get "/" => sub {
     my $c = shift;
+    $c->{config} = $config;
     app->log->info(
         "Will store tokens at" . $config->getFilename( $config->pathToFile ) );
     if ( $c->param('code') ) {
@@ -134,18 +135,28 @@ get "/" => sub {
 
 app->start;
 
+=pod
+<%=
+$config->get('gapi/scopes');
+%>
+scope => $c->{config}->get('gapi/scopes'), ##
+
+=cut
+
 __DATA__
 
 @@ oauth.html.ep
 
 <%= link_to "Click here to get Mojo tokens", $c->oauth2->auth_url("google",
-		scope => "email profile https://www.googleapis.com/auth/plus.profile.emails.read https://www.googleapis.com/auth/calendar https://www.googleapis.com/auth/contacts.readonly",
+		scope => $c->{config}->get('gapi/scopes'), ## scope => "email profile https://www.googleapis.com/auth/plus.profile.emails.read https://www.googleapis.com/auth/calendar https://www.googleapis.com/auth/contacts.readonly",
 		authorize_query => { access_type => 'offline'} )
 %>
 
 <br>
-NB: Scopes are currently hard coded in Server.pm
+NB: Scopes are currently hard coded in WebService::Google::Client::Server -- 
+
 <br>
 
 <a href="https://developers.google.com/+/web/api/rest/oauth#authorization-scopes">
 Check more about authorization scopes</a>
+Once you have a token in your config.json you can check the available scopes with curl using <pre>curl https://www.googleapis.com/oauth2/v1/tokeninfo?access_token=<YOUR_ACCESS_TOKEN></pre>

--- a/lib/WebService/Google/Client/Server.pm
+++ b/lib/WebService/Google/Client/Server.pm
@@ -143,7 +143,9 @@ __DATA__
 		authorize_query => { access_type => 'offline'} )
 %>
 
-<br><br>
+<br>
+NB: Scopes are currently hard coded in Server.pm
+<br>
 
 <a href="https://developers.google.com/+/web/api/rest/oauth#authorization-scopes">
 Check more about authorization scopes</a>

--- a/lib/WebService/Google/UserAgent.pm
+++ b/lib/WebService/Google/UserAgent.pm
@@ -47,9 +47,9 @@ sub build_headers {
   Example of usage:
 
       $gapi->build_http_transaction({
-        method => 'post',
-        route => 'https://www.googleapis.com/calendar/users/me/calendarList',
-        payload => { key => value }
+        httpMethod => 'post',
+        path => 'https://www.googleapis.com/calendar/users/me/calendarList',
+        options => { key => value }
       })
 
 =cut


### PR DESCRIPTION
looks to me like the params defined have been changed from a previous version without updating the POD?
Hi sdonley - am trying to trace my way through this repo though I'm not intimately familiar with Moo and some of the other components which is why I'm pushing through you instead of Pavel in case you are interested in a few patches to make this usable beyond the calendar api. Am also looking to work out a fix for the hard-coded scope limitations in goauth and adding in a few examples on how to use lower level calls to manually construct requests for the non calendar APIS to include in the README and explain the limitations etc to rpevent ppl like me spinning on the assumption that the generated classes will deal with the complex methods of endpoints deeper than top level discovery spec. Let me know if you have any time to review my pulls and if not I'll try Pavel directly instead. Hope that ym approach is ok here. 